### PR TITLE
fix typo

### DIFF
--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -53,7 +53,7 @@ Firehoseサーバーは、P2PネットワークとWebSocketクライアント間
 FirehoseサーバーにWebsocketでメッセージを送信することでP2Pネットワークにメッセージを送信することができます。
 
 ```typescript
-const firehoseUrl = "localhost:8080";
+const firehoseUrl = "ws://localhost:8080";
 const ws = new WebSocket(firehoseUrl);
 
 ws.addEventListener("open", (event) => {


### PR DESCRIPTION
This pull request makes a small but important correction to the WebSocket connection example in the documentation. The change ensures that the WebSocket URL includes the correct protocol prefix.

* Updated the `firehoseUrl` variable in the code sample to use the `ws://` protocol, ensuring proper WebSocket connection syntax in `docs/src/content/docs/quick-start.md`.