### PR TITLE
nodejs24に更新

### DIFF
--- a/.changeset/two-weeks-appear.md
+++ b/.changeset/two-weeks-appear.md
@@ -1,0 +1,7 @@
+---
+"@aikyo/firehose": minor
+"@aikyo/server": minor
+"@aikyo/utils": minor
+---
+
+nodejsバージョンを24に更新

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/README-ja.md
+++ b/README-ja.md
@@ -25,7 +25,7 @@ $ pnpm i @aikyo/utils @aikyo/server @aikyo/firehose
 
 ### 前提ツール
 
-`pnpm` , `Node.js` (>= 22)
+`pnpm` , `Node.js` (>= 24.2)
 
 <details><summary>Nix Flakeを使う場合</summary>
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Contributions are welcome!
 
 ### Requirements
 
-`pnpm` , `Node.js` (>= 22)
+`pnpm` , `Node.js` (>= 24.2)
 
 <details><summary>Using Nix Flake</summary>
 

--- a/flake.lock
+++ b/flake.lock
@@ -85,6 +85,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1757873102,
+        "narHash": "sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF+44xG/xar2yE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88cef159e47c0dc56f151593e044453a39a6e547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "purescript-overlay": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -136,7 +152,8 @@
         "nixpkgs": [
           "dream2nix",
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "slimlock": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     dream2nix.url = "github:nix-community/dream2nix";
     nixpkgs.follows = "dream2nix/nixpkgs";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
@@ -14,6 +15,7 @@
       perSystem = { system, ... }:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
 
         readPkgJson = path:
           let p = builtins.fromJSON (builtins.readFile (path + "/package.json"));
@@ -56,7 +58,7 @@
             program =
               (pkgs.writeShellApplication {
                 name = "dev";
-                runtimeInputs = [ pkgs.nodejs_22 pkgs.pnpm pkgs.coreutils ];
+                runtimeInputs = [ unstable.nodejs_24 pkgs.pnpm pkgs.coreutils ];
                 text = ''
                   #!/usr/bin/env bash
                   set -euo pipefail
@@ -95,7 +97,7 @@
             program =
               (pkgs.writeShellApplication {
                 name = "docs";
-                runtimeInputs = [ pkgs.nodejs_22 pkgs.pnpm ];
+                runtimeInputs = [ unstable.nodejs_24 pkgs.pnpm ];
                 text = ''
                   cd docs
                   exec pnpm run dev "$@"
@@ -106,7 +108,7 @@
 
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
-            nodejs_22
+            unstable.nodejs_24
             pnpm
             git
             watchexec

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "22"
+node = "24"
 pnpm = "latest"

--- a/packages/firehose/index.ts
+++ b/packages/firehose/index.ts
@@ -111,11 +111,12 @@ export class Firehose {
     console.log(`aikyo firehose server running on ws://localhost:${this.port}`);
   }
 }
-
-const firehose = new Firehose(8080);
-try {
-  await firehose.start();
-} catch (err) {
-  console.error("Failed to start firehose:", err);
-  process.exit(1);
+if (import.meta.main) {
+  const firehose = new Firehose(8080);
+  try {
+    await firehose.start();
+  } catch (err) {
+    console.error("Failed to start firehose:", err);
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
# 概要
Node.jsをv22から24.8(nixpkgs-unstable)に更新

## Why
#61
firehoseサーバーでif([import.meta.main](https://nodejs.org/api/esm.html#importmetamain))使用していたけど、これはnodejs v24.2以降の機能だったため。
import.meta.mainを追加する理由として、`$ npx "@aikyo/firehose"`を実行する場合と`import @aikyo/firehose`をする場合で動作を分けるため