### PR TITLE
htmlの言語設定をenからjaに変更した

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -9,6 +9,13 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "aikyo",
+      locales: {
+        root: {
+          label: "日本語",
+          lang: "ja",
+        },
+      },
+      defaultLocale: "ja",
       social: [
         {
           icon: "github",

--- a/docs/src/content/docs/quick-start.mdx
+++ b/docs/src/content/docs/quick-start.mdx
@@ -29,7 +29,7 @@ pnpm add @aikyo/server @aikyo/utils @aikyo/firehose zod @ai-sdk/anthropic dotenv
 
 <Aside type="caution">aikyoは複数のLLMを同時に稼働させるため、通常よりもクレジットを消費します。必ず適切なリミットを設定してから使用してください。</Aside>
 
-```: .env
+```ini title=".env"
 ANTHROPIC_API_KEY="sk-ant-xxxxxxxx"
 ```
 


### PR DESCRIPTION
# 変更内容
- htmlの言語設定をenからjaにした。
- ついでに、.envがハイライトできなくてエラー吐いてたので直した。