### PR TITLE
docs: firehoseサーバーとqueryのドキュメントを更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ aikyoは、相互接続されたAIコンパニオンを構築するためのフ�
   - `CompanionServer`: libp2pベースのP2Pサーバー、TurnTakingManager統合
 - **packages/firehose/**: WebSocketを使用したメッセージング用のP2Pファイアホースサーバー
   - libp2pのpubsubをWebSocketでブリッジ
-  - `messages`, `queries`, `actions`トピックをSubscribe
+  - 型安全なトピックハンドラー管理 (`TopicPayloads`)
+  - カスタマイズ可能なlibp2p設定
+  - `subscribe()`, `addHandler()`, `broadcastToClients()`メソッド
 - **packages/utils/**: ユーティリティとlibp2p関連の共通機能
   - `createCompanionAction`: Actionツールの作成ヘルパー
   - `createCompanionKnowledge`: Knowledgeツールの作成ヘルパー
@@ -76,12 +78,18 @@ cp .env.example .env
 ### Running the System
 ```bash
 # 1. ファイアホースサーバーの起動 (localhost:8080)
+# scripts/firehose.ts を実行（messages, queries, actions トピックをサブスクライブ）
 pnpm run firehose
 
 # 2. コンパニオンの起動（別ターミナルで）
 pnpm run companion <companion_name>
 # 例: pnpm run companion aya
 ```
+
+**Note:** `pnpm run firehose`は`scripts/firehose.ts`を実行します。このスクリプトは：
+- Firehoseサーバーを起動（ポート8080）
+- `messages`, `queries`, `actions`トピックをサブスクライブ
+- 各トピックのメッセージをWebSocketクライアントにブロードキャスト
 
 ### Code Quality
 ```bash
@@ -154,6 +162,89 @@ export const companionCard: CompanionCard = {
     ]
   }
 };
+```
+
+## Advanced Configuration
+
+### libp2p設定のカスタマイズ
+
+**Firehose**と**CompanionServer**の両方で、libp2pノードの設定をカスタマイズできます。
+
+**注意**: カスタム設定を使用する場合は、完全な設定を提供する必要があります（トランスポート、ピアディスカバリー、暗号化、ストリームマルチプレクサ、サービスなど）。
+
+#### Firehose
+
+```typescript
+import { Firehose } from "@aikyo/firehose";
+import { gossipsub } from "@chainsafe/libp2p-gossipsub";
+import { noise } from "@chainsafe/libp2p-noise";
+import { yamux } from "@chainsafe/libp2p-yamux";
+import { identify } from "@libp2p/identify";
+import { mdns } from "@libp2p/mdns";
+import { tcp } from "@libp2p/tcp";
+
+const firehose = new Firehose(8080, {
+  addresses: { listen: ["/ip4/0.0.0.0/tcp/9000"] },
+  transports: [tcp()],
+  peerDiscovery: [mdns()],
+  connectionEncrypters: [noise()],
+  streamMuxers: [yamux()],
+  services: {
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true }),
+    identify: identify(),
+  },
+});
+await firehose.start();
+```
+
+#### CompanionServer
+
+```typescript
+import { CompanionServer } from "@aikyo/server";
+import { gossipsub } from "@chainsafe/libp2p-gossipsub";
+import { noise } from "@chainsafe/libp2p-noise";
+import { yamux } from "@chainsafe/libp2p-yamux";
+import { identify } from "@libp2p/identify";
+import { mdns } from "@libp2p/mdns";
+import { tcp } from "@libp2p/tcp";
+
+const server = new CompanionServer(
+  companionAgent,
+  history,
+  { timeoutDuration: 1000 },
+  {
+    addresses: { listen: ["/ip4/0.0.0.0/tcp/9001"] },
+    transports: [tcp()],
+    peerDiscovery: [mdns()],
+    connectionEncrypters: [noise()],
+    streamMuxers: [yamux()],
+    services: {
+      pubsub: gossipsub({
+        allowPublishToZeroTopicPeers: true,
+        emitSelf: true,
+      }),
+      identify: identify(),
+    },
+  }
+);
+await server.start();
+```
+
+### Firehoseのトピック管理
+
+Firehoseでは型安全なトピックハンドラーを登録できます：
+
+```typescript
+// トピックをサブスクライブしてハンドラーを登録
+await firehose.subscribe("messages", (data) => {
+  console.log("Message:", data);
+  firehose.broadcastToClients(data);
+});
+
+// 追加のハンドラーを登録
+firehose.addHandler("messages", (data) => {
+  // 追加の処理...
+});
 ```
 
 ## Development Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,13 @@ aikyoは、相互接続されたAIコンパニオンを構築するためのフ�
 - **packages/utils/**: ユーティリティとlibp2p関連の共通機能
   - `createCompanionAction`: Actionツールの作成ヘルパー
   - `createCompanionKnowledge`: Knowledgeツールの作成ヘルパー
-- **configs/**: 各AIコンパニオンの設定ファイル（aya、kyokoなど）
-- **scripts/**: companion.tsによるコンパニオン起動スクリプト
-- **apm_dependencies/**: カスタムのAction・Knowledgeツール定義
-  - `core/`: speakToolやcompanionNetworkKnowledgeなど基本ツール
-  - `query-tool/`: visionKnowledgeなど拡張ツール
+- **companions/**: 各AIコンパニオンの設定ファイル（aya、kyokoなど）
+  - 各コンパニオンは `companions/<name>/companion.ts` に定義
+  - `tools/core/`: speakToolやcompanionNetworkKnowledgeなど基本ツール
+  - `tools/query-tool/`: visionKnowledgeなど拡張ツール
+- **scripts/**: 起動スクリプト
+  - `companion.ts`: コンパニオンを名前指定で起動（`companions/`から読み込み）
+  - `firehose.ts`: Firehoseサーバーを起動し、messages/queries/actionsトピックをサブスクライブ
 
 ### Core Concepts
 
@@ -131,9 +133,9 @@ pnpm run release
 
 ## Companion Configuration
 
-`configs/`ディレクトリ内に各コンパニオンの設定があります。新しいコンパニオンを追加する場合は：
+`companions/`ディレクトリ内に各コンパニオンの設定があります。新しいコンパニオンを追加する場合は：
 
-1. `configs/<name>/`ディレクトリを作成
+1. `companions/<name>/`ディレクトリを作成
 2. `companion.ts`ファイルで`CompanionCard`を実装：
    - `metadata`: id、name、personality、story、sample
    - `role`: コンパニオンの役割記述
@@ -250,7 +252,7 @@ firehose.addHandler("messages", (data) => {
 ## Development Guidelines
 
 ### カスタムツールの作成
-`apm_dependencies/`ディレクトリにツールを追加：
+`companions/tools/`ディレクトリにツールを追加：
 - **Action**: `createCompanionAction`でネットワークへの送信機能を実装
 - **Knowledge**: `createCompanionKnowledge`で情報取得機能を実装
 

--- a/docs/src/content/docs/api/firehose.md
+++ b/docs/src/content/docs/api/firehose.md
@@ -14,7 +14,7 @@ import { Firehose } from "@aikyo/firehose";
 ## コンストラクタ
 
 ```typescript
-constructor(port: number)
+constructor(port: number, libp2pConfig?: Libp2pOptions<Services>)
 ```
 
 ### パラメータ
@@ -22,14 +22,41 @@ constructor(port: number)
 | パラメータ | 型 | 説明 |
 |-----------|-----|------|
 | `port` | `number` | WebSocketサーバーのポート番号 |
+| `libp2pConfig` | `Libp2pOptions<Services>` | オプション。libp2pノードのカスタム設定 |
 
 ### 使用例
 
 ```typescript
 import { Firehose } from "@aikyo/firehose";
 
+// 基本的な使用（デフォルト設定）
 const firehose = new Firehose(8080);
 await firehose.start();
+```
+
+カスタムlibp2p設定を使用する場合は、完全な設定を提供する必要があります：
+
+```typescript
+import { Firehose } from "@aikyo/firehose";
+import { gossipsub } from "@chainsafe/libp2p-gossipsub";
+import { noise } from "@chainsafe/libp2p-noise";
+import { yamux } from "@chainsafe/libp2p-yamux";
+import { identify } from "@libp2p/identify";
+import { mdns } from "@libp2p/mdns";
+import { tcp } from "@libp2p/tcp";
+
+const customFirehose = new Firehose(8080, {
+  addresses: { listen: ["/ip4/0.0.0.0/tcp/9000"] },
+  transports: [tcp()],
+  peerDiscovery: [mdns()],
+  connectionEncrypters: [noise()],
+  streamMuxers: [yamux()],
+  services: {
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true }),
+    identify: identify(),
+  },
+});
+await customFirehose.start();
 ```
 
 ## プロパティ
@@ -92,6 +119,35 @@ private readonly port: number
 
 WebSocketサーバーのポート番号。
 
+### topicHandlers
+
+```typescript
+private topicHandlers: {
+  [K in keyof TopicPayloads]: ((data: TopicPayloads[K]) => void)[];
+}
+```
+
+トピックごとのハンドラー関数を管理するオブジェクト。型安全なイベント処理を提供します。
+
+```typescript
+type TopicPayloads = {
+  messages: Message;
+  queries: Query | QueryResult;
+  actions: Action;
+  states: State;
+};
+```
+
+各トピックに対して複数のハンドラーを登録でき、メッセージ受信時に順次実行されます。
+
+### libp2pConfig
+
+```typescript
+private libp2pConfig?: Libp2pOptions<Services>
+```
+
+オプション。libp2pノードのカスタム設定。指定しない場合はデフォルト設定が使用されます。
+
 ## メソッド
 
 ### start()
@@ -100,4 +156,122 @@ Firehoseサーバーを起動します。
 
 ```typescript
 async start(): Promise<void>
+```
+
+**処理フロー:**
+
+1. libp2pノードを初期化
+2. WebSocketサーバーを起動
+3. イベントリスナーを登録
+
+**出力例:**
+
+```
+aikyo firehose server running on ws://localhost:8080
+```
+
+### subscribe()
+
+指定したトピックをサブスクライブし、オプションでハンドラーを登録します。
+
+```typescript
+async subscribe<K extends keyof TopicPayloads>(
+  topic: K,
+  handler?: (data: TopicPayloads[K]) => void
+): Promise<void>
+```
+
+**パラメータ:**
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `topic` | `keyof TopicPayloads` | サブスクライブするトピック名（`"messages"`, `"queries"`, `"actions"`, `"states"`） |
+| `handler` | `function` | オプション。メッセージ受信時に実行するハンドラー関数 |
+
+**使用例:**
+
+```typescript
+// トピックのサブスクライブのみ
+await firehose.subscribe("messages");
+
+// ハンドラー付きでサブスクライブ
+await firehose.subscribe("messages", (data) => {
+  console.log("Message received:", data);
+  firehose.broadcastToClients(data);
+});
+```
+
+### addHandler()
+
+既存のトピックにハンドラーを追加します。
+
+```typescript
+addHandler<K extends keyof TopicPayloads>(
+  topic: K,
+  handler: (data: TopicPayloads[K]) => void
+): void
+```
+
+**パラメータ:**
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `topic` | `keyof TopicPayloads` | トピック名 |
+| `handler` | `function` | メッセージ受信時に実行するハンドラー関数 |
+
+**使用例:**
+
+```typescript
+firehose.addHandler("actions", (action) => {
+  console.log("Action received:", action);
+});
+```
+
+### broadcastToClients()
+
+接続中の全WebSocketクライアントにデータをブロードキャストします。
+
+```typescript
+broadcastToClients(data: unknown): void
+```
+
+**パラメータ:**
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `data` | `unknown` | ブロードキャストするデータ（JSON.stringifyされます） |
+
+**使用例:**
+
+```typescript
+firehose.broadcastToClients({
+  type: "notification",
+  message: "Hello, clients!"
+});
+```
+
+## 完全な使用例
+
+`scripts/firehose.ts`の実装例：
+
+```typescript
+import { Firehose } from "@aikyo/firehose";
+
+const firehose = new Firehose(8080);
+await firehose.start();
+
+// messagesトピックをサブスクライブし、クライアントにブロードキャスト
+await firehose.subscribe("messages", (data) => {
+  firehose.broadcastToClients(data);
+});
+
+// queriesトピックをサブスクライブし、クライアントにブロードキャスト
+await firehose.subscribe("queries", (data) => {
+  firehose.broadcastToClients(data);
+});
+
+// actionsトピックをサブスクライブし、クライアントにブロードキャスト
+await firehose.subscribe("actions", (data) => {
+  firehose.broadcastToClients(data);
+});
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Firehose と CompanionServer でカスタム libp2p 設定の注入に対応し、起動時に任意の構成を指定可能に。
- ドキュメント
  - 高度な設定ガイドを大幅拡充（トランスポート、ディスカバリ、暗号化、Mux、PubSub 等の具体例を追加）。
  - Firehose のトピック管理とクライアント配信の使用例を追加。
  - CompanionServer のコンストラクタ引数に libp2p 設定の解説を追加。
  - Query 結果のレスポンス仕様を更新（成功は result 内、エラーはトップレベル error へ統一）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->