### PR TITLE
arXivのリンクからJournalのリンクに変更

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -102,7 +102,7 @@ $ pnpm run companion <companion_name>
 aikyoは以下の論文にインスパイアされました:
 
 > **"Who Speaks Next? Multi-party AI Discussion Leveraging the Systematics of Turn-taking in Murder Mystery Games"**  
-by Ryota Nonomura and Hiroki Mori (2024)  
-📄 [arXiv:2412.04937](https://arxiv.org/abs/2412.04937)
+by Ryota Nonomura and Hiroki Mori (2025)  
+📄 [Journal](https://doi.org/10.3389/frai.2025.1582287)
 
 マルチエージェントの対話制御に関する素晴らしい研究に感謝します！

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ pnpm run companion <companion_name>
 This project is inspired by the research paper:
 
 > **"Who Speaks Next? Multi-party AI Discussion Leveraging the Systematics of Turn-taking in Murder Mystery Games"**  
-by Ryota Nonomura and Hiroki Mori (2024)  
-📄 [arXiv:2412.04937](https://arxiv.org/abs/2412.04937)
+by Ryota Nonomura and Hiroki Mori (2025)  
+📄 [Journal](https://doi.org/10.3389/frai.2025.1582287)
 
 We appreciate their groundbreaking work on multi-agent dialogue systems and turn-taking mechanisms.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* ドキュメント
  * READMEおよびREADME-jaの謝辞に記載の引用を更新（2024年のarXiv参照を2025年のジャーナルDOIに置換）
  * 対象箇所のリンク先をDOIへ変更し、表記年を2025年に統一
  * 内容の明確化と参照の最新化を実施
  * アプリの機能・挙動への影響はありません

<!-- end of auto-generated comment: release notes by coderabbit.ai -->