### PR TITLE
feat(firehose): libディレクトリのエクスポートを追加

### DIFF
--- a/packages/firehose/index.ts
+++ b/packages/firehose/index.ts
@@ -138,3 +138,5 @@ export class Firehose {
     }
   }
 }
+
+export { logger } from "./lib/logger.js";

--- a/packages/firehose/package.json
+++ b/packages/firehose/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./lib/*": {
+      "types": "./dist/lib/*.d.ts",
+      "default": "./dist/lib/*.js"
+    },
     "./*": {
       "types": "./dist/*.d.ts",
       "default": "./dist/*.js"


### PR DESCRIPTION
## Summary
- package.jsonに`./lib/*`エクスポートパターンを追加し、`./dist/lib/*.d.ts`と`./dist/lib/*.js`を公開
- index.tsから`logger`を再エクスポート
- ビルド設定により`dist/lib/`ディレクトリが正しく生成されることを確認

## 変更内容
コンシューマーは以下の方法でloggerモジュールにアクセス可能になります：
```typescript
import { logger } from "@aikyo/firehose"
// または
import { logger } from "@aikyo/firehose/lib/logger"
```

## Test plan
- [x] `pnpm --filter @aikyo/firehose build`を実行し、`dist/lib/logger.js`と`dist/lib/logger.d.ts`が生成されることを確認
- [ ] 他のパッケージから`@aikyo/firehose/lib/logger`としてインポートできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)