### PR TITLE
fix: mattermost-github-watcherのバージョンを0.1.5に更新

### DIFF
--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -8,7 +8,7 @@ jobs:
   post-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: Gen5HQ/mattermost-github-watcher@0.1.2
+      - uses: Gen5HQ/mattermost-github-watcher@0.1.5
         with:
           mattermost_webhook_url: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
           gh_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD ワークフローの依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->